### PR TITLE
Comprehend one-time classification & anonymize ARNs, S3 URIs, and resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After training your classifier and creating an endpoint, you should have a Compr
 
 Navigate to ```docsplitter/document_split_workflow.py``` and modify lines 26-27 which contain ```comprehend_classifier_endpoint```. Paste in your endpoint ARN [in this line](https://github.com/aws-samples/aws-textract-cdk-commercial-acord/blob/main/docsplitter/document_split_workflow.py#L27). It should be in the form: 
 
-```arn:aws:comprehend:<your-region>:<your-account-id>:document-classifier-endpoint/<your-classifier-name>```.
+```arn:aws:comprehend:<REGION>:<ACCOUNT_ID>:document-classifier-endpoint/<CLASSIFIER_NAME>```.
 
 
 ### 2. Document Configuration Table
@@ -117,16 +117,16 @@ Clicking on the "Execution input & output tab" at the top show the overall input
 ```
 [
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-10xun1pqvc3j7/textract-csv-output/acord125_pages_1-4_2023-01-05T03:14:28.110714.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord125_pages_1-4_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-10xun1pqvc3j7/textract-csv-output/acord126_pages_5-8_2023-01-05T03:14:28.146333.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord126_pages_5-8_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-10xun1pqvc3j7/textract-csv-output/acord140_pages_9-11_2023-01-05T03:14:28.070567.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord140_pages_9-11_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-10xun1pqvc3j7/textract-csv-output/property_affidavit_pages_12-12_2023-01-05T03:14:28.073459.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/property_affidavit_pages_12-12_<TIMESTAMP>.csv"
   }
 ]
 ```
@@ -141,10 +141,10 @@ Run the script using:
 
 In the ```csvfiles_<timestamp>``` folder, you should see:
 
-```acord125_pages_1-4_<timestamp>.csv```
+```acord125_pages_1-4_<TIMESTAMP>.csv```
 
-```acord126_pages_5-8_<timestamp>.csv```
+```acord126_pages_5-8_<TIMESTAMP>.csv```
 
-```acord140_pages_9-11_<timestamp>.csv```
+```acord140_pages_9-11_<TIMESTAMP>.csv```
 
-```property_affidavit_pages_12-12_<timestamp>.csv```
+```property_affidavit_pages_12-12_<TIMESTAMP>.csv```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://github.com/aws-samples/aws-document-classifier-and-splitter.
 
 After training your classifier and creating an endpoint, you should have a Comprehend Custom Classification Endpoint ARN. 
 
-Navigate to ```docsplitter/document_split_workflow.py``` and modify lines 26-27 which contain ```comprehend_classifier_endpoint```. Paste in your endpoint ARN [in this line](https://github.com/aws-samples/aws-textract-cdk-commercial-acord/blob/main/docsplitter/document_split_workflow.py#L27). It should be in the form: 
+Navigate to ```docsplitter/document_split_workflow.py``` and modify lines 27-28 which contain ```comprehend_classifier_endpoint```. Paste in your endpoint ARN [in this line](https://github.com/aws-samples/aws-textract-cdk-commercial-acord/blob/main/docsplitter/document_split_workflow.py#L28). It should be in the form: 
 
 ```arn:aws:comprehend:<REGION>:<ACCOUNT_ID>:document-classifier-endpoint/<CLASSIFIER_NAME>```.
 

--- a/docsplitter/document_split_workflow.py
+++ b/docsplitter/document_split_workflow.py
@@ -24,7 +24,7 @@ class DocumentSplitterWorkflow(Stack):
         s3_csv_output_prefix = "textract-csv-output"
         s3_joined_output_prefix = "textract-joined-output"
         comprehend_classifier_endpoint = \
-            "arn:aws:comprehend:us-east-1:988522673913:document-classifier-endpoint/Classifier-20230110004248"
+            "arn:aws:comprehend:<REGION>:<ACCOUNT_ID>:document-classifier-endpoint/<CLASSIFIER_NAME>"
 
         # BEWARE! This is a demo/POC setup, remove the auto_delete_objects=True
         # to make sure the data is not lost

--- a/docsplitter/document_split_workflow.py
+++ b/docsplitter/document_split_workflow.py
@@ -7,8 +7,10 @@ import aws_cdk.aws_stepfunctions_tasks as tasks
 import aws_cdk.aws_lambda as lambda_
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_dynamodb as dynamodb
+import aws_cdk.aws_sqs as sqs
 import aws_cdk.custom_resources as custom_resources
 from aws_cdk import (CfnOutput, RemovalPolicy, Stack, Duration, Aws, CustomResource)
+from aws_cdk.aws_lambda_event_sources import SqsEventSource
 import amazon_textract_idp_cdk_constructs as tcdk
 
 
@@ -16,11 +18,10 @@ class DocumentSplitterWorkflow(Stack):
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-        
+
         script_location = os.path.dirname(__file__)
         s3_upload_prefix = "uploads"
         s3_output_prefix = "textract-output"
-        s3_txt_output_prefix = "textract-text-output"
         s3_csv_output_prefix = "textract-csv-output"
         s3_joined_output_prefix = "textract-joined-output"
         comprehend_classifier_endpoint = \
@@ -38,7 +39,65 @@ class DocumentSplitterWorkflow(Stack):
         s3_output_bucket = document_bucket.bucket_name
         workflow_name = "DocumentSplitterWorkflow"
 
-        # DEFINE Lambda functions, policies, DynamoDB table, Provider, CustomResource ###############
+        # DEFINE Lambda functions, policies, SQS queue, SQS EventSource,
+        # DynamoDB table, Provider, CustomResource
+        comprehend_sync_sqs = sqs.Queue(
+            self,
+            'ComprehendRequests',
+            visibility_timeout=Duration.seconds(360)
+        ) # visibility_timeout should be at least six times comprehend_sync_call_function timeout
+
+        put_on_sqs_function = lambda_.DockerImageFunction(
+            self,
+            'PutOnSQS',
+            code=lambda_.DockerImageCode.from_image_asset(os.path.join(script_location,
+                                                                       '../lambda/put_on_sqs/')),
+            architecture=lambda_.Architecture.X86_64,
+            memory_size=256,
+            timeout=Duration.seconds(60),
+            environment={
+                "LOG_LEVEL": "DEBUG",
+                "SQS_QUEUE_URL": comprehend_sync_sqs.queue_url,
+                "SQS_MAX_DELAY": "10"
+            }
+        )
+        put_on_sqs_function.add_to_role_policy(iam.PolicyStatement(
+            actions=['sqs:SendMessage'], resources=[comprehend_sync_sqs.queue_arn]
+        ))
+
+        comprehend_sync_call_function = lambda_.DockerImageFunction(
+            self,
+            'ComprehendSyncCall',
+            code=lambda_.DockerImageCode.from_image_asset(os.path.join(script_location,
+                                                                       '../lambda/comprehend_sync/')),
+            memory_size=256,
+            timeout=Duration.seconds(60),
+            environment={
+                "LOG_LEVEL": "DEBUG",
+                "SQS_QUEUE_URL": comprehend_sync_sqs.queue_url,
+                "SQS_MAX_RETRIES": "4",
+                "SQS_MIN_VIS_TIMEOUT": "5",
+                "SQS_MAX_VIS_TIMEOUT": "15",
+                "COMPREHEND_CLASSIFIER_ARN": comprehend_classifier_endpoint
+            }
+        )
+        comprehend_sync_call_function.add_event_source(SqsEventSource(comprehend_sync_sqs, batch_size=1))
+        comprehend_sync_call_function.add_to_role_policy(iam.PolicyStatement(
+            actions=['comprehend:ClassifyDocument'], resources=['*']
+        ))
+        comprehend_sync_call_function.add_to_role_policy(iam.PolicyStatement(
+            actions=["textract:Analyze*", "textract:Detect*"],
+            resources=["*"]
+        ))
+        comprehend_sync_call_function.add_to_role_policy(iam.PolicyStatement(
+            actions=['s3:GetObject', 's3:ListBucket', 's3:PutObject'],
+            resources=[f"arn:aws:s3:::{s3_output_bucket}", f"arn:aws:s3:::{s3_output_bucket}/*"]
+        ))
+
+        comprehend_sync_call_function.add_to_role_policy(iam.PolicyStatement(
+            actions=['states:SendTaskFailure', 'states:SendTaskSuccess'], resources=['*']
+        ))
+
         lambda_decider: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaDecider",
@@ -52,7 +111,7 @@ class DocumentSplitterWorkflow(Stack):
             iam.PolicyStatement(
                 actions=["s3:GetObject"],
                 resources=[f"arn:aws:s3:::{s3_output_bucket}", f"arn:aws:s3:::{s3_output_bucket}/*"]))
-        
+
         lambda_textract_sync: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaTextractSync",
@@ -79,30 +138,7 @@ class DocumentSplitterWorkflow(Stack):
             iam.PolicyStatement(
                 actions=['states:SendTaskFailure', 'states:SendTaskSuccess'],
                 resources=["*"]))
-        
-        lambda_generate_text: lambda_.IFunction = lambda_.DockerImageFunction(
-            self,
-            "LambdaGenerateText",
-            code=lambda_.DockerImageCode.from_image_asset(
-                os.path.join(script_location,
-                             '../lambda/generatecsv/')),
-            memory_size=1048,
-            timeout=Duration.minutes(15),
-            architecture=lambda_.Architecture.X86_64,
-            environment={
-                "LOG_LEVEL": "DEBUG",
-                "CSV_S3_OUTPUT_BUCKET": s3_output_bucket,
-                "CSV_S3_OUTPUT_PREFIX": s3_txt_output_prefix,
-                "OUTPUT_TYPE": "LINES"})
-        lambda_generate_text.add_to_role_policy(
-            iam.PolicyStatement(
-                actions=['s3:Get*', 's3:List*', 's3:PutObject'],
-                resources=[f"arn:aws:s3:::{s3_output_bucket}", f"arn:aws:s3:::{s3_output_bucket}/*"]))
-        lambda_generate_text.add_to_role_policy(
-            iam.PolicyStatement(
-                actions=['states:SendTaskFailure', 'states:SendTaskSuccess'],
-                resources=["*"]))
-        
+
         lambda_generate_csv: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaGenerateCSV",
@@ -115,8 +151,7 @@ class DocumentSplitterWorkflow(Stack):
             environment={
                 "LOG_LEVEL": "DEBUG",
                 "CSV_S3_OUTPUT_BUCKET": s3_output_bucket,
-                "CSV_S3_OUTPUT_PREFIX": s3_csv_output_prefix,
-                "OUTPUT_TYPE": "CSV"})
+                "CSV_S3_OUTPUT_PREFIX": s3_csv_output_prefix})
         lambda_generate_csv.add_to_role_policy(
             iam.PolicyStatement(
                 actions=['s3:Get*', 's3:List*', 's3:PutObject'],
@@ -137,7 +172,7 @@ class DocumentSplitterWorkflow(Stack):
             architecture=lambda_.Architecture.X86_64,
             environment={
                 "LOG_LEVEL": "DEBUG"})
-        
+
         configuration_table = dynamodb.Table(
             self,
             "TextractConfigurationTable",
@@ -146,7 +181,7 @@ class DocumentSplitterWorkflow(Stack):
             ),
             removal_policy=RemovalPolicy.DESTROY,
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST)
-        
+
         lambda_config_prefill: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaConfigurationPrefill",
@@ -164,13 +199,13 @@ class DocumentSplitterWorkflow(Stack):
                 actions=['dynamodb:PutItem', 'dynamodb:GetItem'],
                 resources=[configuration_table.table_arn]))
         lambda_config_prefill.node.add_dependency(configuration_table)
-        
+
         provider = custom_resources.Provider(
             self,
             "Provider",
             on_event_handler=lambda_config_prefill)
         CustomResource(self, "Resource", service_token=provider.service_token)
-            
+
         lambda_configurator: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaClassificationConfigurator",
@@ -187,7 +222,7 @@ class DocumentSplitterWorkflow(Stack):
             iam.PolicyStatement(
                 actions=['dynamodb:PutItem', 'dynamodb:GetItem'],
                 resources=[configuration_table.table_arn]))
-        
+
         lambda_generate_classification_mapping: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaGenerateClassificationMapping",
@@ -196,7 +231,7 @@ class DocumentSplitterWorkflow(Stack):
                              '../lambda/map_classifications_lambda/')),
             memory_size=128,
             architecture=lambda_.Architecture.X86_64)
-        
+
         lambda_compile_paths: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaCompilePaths",
@@ -208,7 +243,7 @@ class DocumentSplitterWorkflow(Stack):
             architecture=lambda_.Architecture.X86_64,
             environment={
                 "LOG_LEVEL": "DEBUG"})
-        
+
         lambda_join_csv: lambda_.IFunction = lambda_.DockerImageFunction(
             self,
             "LambdaJoinCSV",
@@ -243,12 +278,12 @@ class DocumentSplitterWorkflow(Stack):
             "TaskDocumentSplitter",
             s3_output_bucket=s3_output_bucket,
             s3_output_prefix=s3_output_prefix)
-        
+
         # Step Functions task to call Textract
-        textract_sync_ocr_task = tasks.LambdaInvoke(
+        comprehend_sync_task = tasks.LambdaInvoke(
             self,
-            "TaskTextractSyncOCR",
-            lambda_function=lambda_textract_sync,
+            'TaskClassification',
+            lambda_function=put_on_sqs_function,
             integration_pattern=sfn.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
             timeout=Duration.hours(24),
             payload=sfn.TaskInput.from_object({
@@ -258,47 +293,6 @@ class DocumentSplitterWorkflow(Stack):
                 sfn.JsonPath.string_at('$$.Execution.Id'),
                 "Payload":
                 sfn.JsonPath.entire_payload,
-            }),
-            result_path="$.textract_result")
-        textract_sync_ocr_task.add_retry(
-            max_attempts=1,
-            backoff_rate=1,
-            interval=Duration.seconds(1),
-            errors=['ThrottlingException', 'LimitExceededException',
-                    'InternalServerError', 'ProvisionedThroughputExceededException'])
-
-        # Step Functions task to generate text file from Textract JSON output
-        generate_text_task = tasks.LambdaInvoke(
-            self,
-            "TaskGenerateText",
-            lambda_function=lambda_generate_text,
-            integration_pattern=sfn.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
-            timeout=Duration.hours(24),
-            payload=sfn.TaskInput.from_object({
-                "Token":
-                sfn.JsonPath.task_token,
-                "ExecutionId":
-                sfn.JsonPath.string_at('$$.Execution.Id'),
-                "Payload":
-                sfn.JsonPath.entire_payload,
-            }),
-            result_path="$.txt_output_location")
-
-        # Step Functions task for classification
-        comprehend_sync_task = tcdk.ComprehendGenericSyncSfnTask(
-            self,
-            "TaskClassification",
-            comprehend_classifier_arn=comprehend_classifier_endpoint,
-            integration_pattern=sfn.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
-            lambda_log_level="DEBUG",
-            timeout=Duration.hours(24),
-            input=sfn.TaskInput.from_object({
-              "Token":
-              sfn.JsonPath.task_token,
-              "ExecutionId":
-              sfn.JsonPath.string_at('$$.Execution.Id'),
-              "Payload":
-              sfn.JsonPath.entire_payload,
             }),
             result_path="$.classification")
 
@@ -314,7 +308,7 @@ class DocumentSplitterWorkflow(Stack):
             lambda_function=lambda_configurator,
             timeout=Duration.seconds(100),
             output_path='$.Payload')
-        
+
         # Step Functions task to call Textract
         textract_sync_queries_task = tasks.LambdaInvoke(
             self,
@@ -360,18 +354,18 @@ class DocumentSplitterWorkflow(Stack):
             "TaskGenerateClassificationMapping",
             lambda_function=lambda_generate_classification_mapping,
             output_path='$.Payload')
-            
+
         compile_paths_task = tasks.LambdaInvoke(
             self,
             "TaskCompilePaths",
             lambda_function=lambda_compile_paths)
-    
+
         join_csv_task = tasks.LambdaInvoke(
             self,
             "TaskJoinCSV",
             lambda_function=lambda_join_csv,
             output_path='$.Payload')
-        
+
         # Step Functions Flow Definition #########
 
         # Routing based on document type
@@ -379,9 +373,9 @@ class DocumentSplitterWorkflow(Stack):
                        .when(sfn.Condition.string_equals('$.classification.documentType', 'NONE'),
                              sfn.Fail(self, "DocumentTypeNotImplemented")) \
                        .otherwise(sfn.Pass(self, "PassState"))
-                    
+
         # Map state to classify pages in parallel
-        # Creates manifest 
+        # Creates manifest
         # Generates S3 path from S3 Document Splitter Output Bucket and Output Path
         classify_pages_map = sfn.Map(
             self,
@@ -403,7 +397,7 @@ class DocumentSplitterWorkflow(Stack):
             self,
             "ProcessPagesMapState",
             items_path=sfn.JsonPath.string_at('$.Payload'))
-        
+
         # Map state to compile each page's CSV into one CSV document
         compile_pages_map = sfn.Map(
             self,
@@ -411,10 +405,8 @@ class DocumentSplitterWorkflow(Stack):
             items_path=sfn.JsonPath.string_at('$.Payload'))
 
         # Classify and route
-        textract_sync_ocr_task.next(generate_text_task) \
-            .next(comprehend_sync_task) \
-            .next(doc_type_choice)
-        classify_pages_map.iterator(textract_sync_ocr_task)
+        comprehend_sync_task.next(doc_type_choice)
+        classify_pages_map.iterator(comprehend_sync_task)
 
         configurator_task.next(textract_sync_queries_task) \
             .next(generate_csv_task) \
@@ -429,13 +421,13 @@ class DocumentSplitterWorkflow(Stack):
             .next(process_pages_map) \
             .next(compile_paths_task) \
             .next(compile_pages_map)
-            
+
         compile_pages_map.iterator(join_csv_task)
 
         state_machine = sfn.StateMachine(self,
                                          workflow_name,
                                          definition=workflow_chain)
-                                         
+
         # Step Functions definition end ###############
 
         # Lambda function to start workflow on new object at S3 bucket/prefix location

--- a/getfiles.py
+++ b/getfiles.py
@@ -8,16 +8,16 @@ s3 = boto3.client("s3")
 
 files = [
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-70uw1q72o402/textract-joined-output/acord125_pages_1-4_2023-01-10T03:49:36.410738.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord125_pages_1-4_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-70uw1q72o402/textract-joined-output/acord126_pages_5-8_2023-01-10T03:49:36.413892.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord126_pages_5-8_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-70uw1q72o402/textract-joined-output/acord140_pages_9-11_2023-01-10T03:49:36.585691.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/acord140_pages_9-11_<TIMESTAMP>.csv"
   },
   {
-    "JoinedCSVOutputPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-70uw1q72o402/textract-joined-output/property_affidavit_pages_12-12_2023-01-10T03:49:36.265905.csv"
+    "JoinedCSVOutputPath": "s3://<S3_OUTPUT_BUCKET>/<S3_JOINED_OUTPUT_PREFIX>/property_affidavit_pages_12-12_<TIMESTAMP>.csv"
   }
 ]
 

--- a/lambda/compile_paths/env.json
+++ b/lambda/compile_paths/env.json
@@ -1,5 +1,5 @@
 {
     "DeciderFunction": {
-        "CONFIGURATION_TABLE": "DocumentSplitterWorkflow-DocumentSplitterWorkflowConfiguratorTextractConfigurationTableF23A3F4D-18401CI5OCUHI"
+        "CONFIGURATION_TABLE": "<CONFIGURATION_TABLE_NAME>"
     }
 }

--- a/lambda/compile_paths/events/event.json
+++ b/lambda/compile_paths/events/event.json
@@ -1,50 +1,50 @@
 [
   {
     "1": "acord125",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:08:27+00:00/1.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/1.csv"
   },
   {
     "2": "acord125",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:27+00:00/2.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/2.csv"
   },
   {
     "3": "acord125",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:30+00:00/3.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/3.csv"
   },
   {
     "4": "acord125",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:54+00:00/4.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/4.csv"
   },
   {
     "5": "acord126",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:08:48+00:00/5.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/5.csv"
   },
   {
     "6": "acord126",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:09+00:00/6.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/6.csv"
   },
   {
     "7": "acord126",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:46+00:00/7.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/7.csv"
   },
   {
     "8": "acord126",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:47+00:00/8.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/8.csv"
   },
   {
     "9": "acord140",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:08:29+00:00/9.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/9.csv"
   },
   {
     "10": "acord140",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:13+00:00/10.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/10.csv"
   },
   {
     "11": "acord140",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:08:07+00:00/11.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/11.csv"
   },
   {
     "12": "property_affidavit",
-    "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T20:07:09+00:00/12.csv"
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/12.csv"
   }
 ]

--- a/lambda/compile_paths/template.yaml
+++ b/lambda/compile_paths/template.yaml
@@ -16,7 +16,7 @@ Resources:
       PackageType: Image
       Environment:
         Variables:
-            CONFIGURATION_TABLE: "DocumentSplitterWorkflow-DocumentSplitterWorkflowConfiguratorTextractConfigurationTableF23A3F4D-18401CI5OCUHI"
+            CONFIGURATION_TABLE: "<CONFIGURATION_TABLE_NAME>"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .

--- a/lambda/comprehend_sync/Dockerfile
+++ b/lambda/comprehend_sync/Dockerfile
@@ -1,0 +1,10 @@
+FROM public.ecr.aws/lambda/python:3.9-x86_64
+
+RUN /var/lang/bin/python -m pip install --upgrade pip
+RUN python -m pip install amazon-textract-caller==0.0.24 schadem-tidp-manifest==0.0.9 marshmallow --target "${LAMBDA_TASK_ROOT}"
+
+# Copy function code
+COPY app/* ${LAMBDA_TASK_ROOT}/
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "sync_main.lambda_handler" ]

--- a/lambda/comprehend_sync/app/entry.sh
+++ b/lambda/comprehend_sync/app/entry.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+    exec /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric $1
+else
+    exec /usr/local/bin/python -m awslambdaric $1
+fi

--- a/lambda/comprehend_sync/app/requirements.txt
+++ b/lambda/comprehend_sync/app/requirements.txt
@@ -1,0 +1,1 @@
+amazon-textract-caller

--- a/lambda/comprehend_sync/app/sync_main.py
+++ b/lambda/comprehend_sync/app/sync_main.py
@@ -1,0 +1,198 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import os
+import time
+from random import randint
+
+import boto3
+import textractmanifest as tm
+
+from botocore.exceptions import ClientError
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+version = "0.0.1"
+s3 = boto3.client('s3')
+step_functions_client = boto3.client(service_name='stepfunctions')
+sqs = boto3.client('sqs')
+
+comprehend = boto3.client("comprehend")
+
+
+def split_s3_path_to_bucket_and_key(s3_path: str) -> Tuple[str, str]:
+    if len(s3_path) > 7 and s3_path.lower().startswith("s3://"):
+        s3_bucket, s3_key = s3_path.replace("s3://", "").split("/", 1)
+        return s3_bucket, s3_key
+    else:
+        raise ValueError(
+            f"s3_path: {s3_path} is no s3_path in the form of s3://bucket/key."
+        )
+
+
+def get_file_bytes_from_s3(s3_path: str) -> bytes:
+    s3_bucket, s3_key = split_s3_path_to_bucket_and_key(s3_path)
+    o = s3.get_object(Bucket=s3_bucket, Key=s3_key)
+    return o.get('Body').read()
+
+
+def send_failure_to_step_function(error, cause, token, sqs_queue_url, message, receipt_handle):
+    try:
+        step_functions_client.send_task_failure(taskToken=token,
+                                                error=error,
+                                                cause=cause)
+    except step_functions_client.exceptions.InvalidToken:
+        logger.error(f"InvalidToken for message: {message} ")
+        sqs.delete_message(QueueUrl=sqs_queue_url,
+                           ReceiptHandle=receipt_handle)
+    except step_functions_client.exceptions.TaskDoesNotExist:
+        logger.error(f"TaskDoesNotExist for message: {message} ")
+        sqs.delete_message(QueueUrl=sqs_queue_url,
+                           ReceiptHandle=receipt_handle)
+    except step_functions_client.exceptions.TaskTimedOut:
+        logger.error(f"TaskTimedOut for message: {message} ")
+        sqs.delete_message(QueueUrl=sqs_queue_url,
+                           ReceiptHandle=receipt_handle)
+
+
+def lambda_handler(event, _):
+    log_level = os.environ.get('LOG_LEVEL', 'DEBUG')
+    logger.setLevel(log_level)
+    logger.info(f"version: {version}\n \
+                textractmanifest version: {tm.__version__}\n \
+                boto3 version: {boto3.__version__}")
+    logger.info(json.dumps(event))
+
+    sqs_queue_url = os.environ.get('SQS_QUEUE_URL', None)
+    if not sqs_queue_url:
+        raise Exception("no SQS_QUEUE_URL set")
+
+    comprehend_classifier_arn = os.environ.get('COMPREHEND_CLASSIFIER_ARN',
+                                               None)
+    if not comprehend_classifier_arn:
+        raise Exception("no COMPREHEND_CLASSIFIER_ARN set")
+
+    sqs_max_retries = os.environ.get('SQS_MAX_RETRIES', 3)
+    sqs_min_vis_timeout = int(os.environ.get('SQS_MIN_VIS_TIMEOUT', 15))
+    sqs_max_vis_timeout = int(os.environ.get('SQS_MAX_VIS_TIMEOUT', 30))
+
+    logger.debug(f"LOG_LEVEL: {log_level} \n \
+                COMPREHEND_CLASSIFIER_ARN: {comprehend_classifier_arn} \n \
+                SQS_QUEUE_URL: {sqs_queue_url} \n \
+                SQS_MAX_RETRIES: {sqs_max_retries} \n \
+                SQS_MIN_VIS_TIMEOUT: {sqs_min_vis_timeout} \n \
+                SQS_MAX_VIS_TIMEOUT: {sqs_max_vis_timeout}")
+
+    for record in event['Records']:
+        if not ("eventSource" in record
+                and record["eventSource"]) == "aws:sqs":
+            raise ValueError("Unsupported eventSource in record")
+
+        message = json.loads(record["body"])
+        token = message['Token']
+        execution_id = message['ExecutionId']
+
+        if "Payload" not in message:
+            raise ValueError("Need Payload with manifest to process message.")
+
+        receipt_handle = record["receiptHandle"]
+        approx_receive_count = record["attributes"]["ApproximateReceiveCount"]
+
+        manifest: tm.IDPManifest = tm.IDPManifestSchema().load(
+            message["Payload"]['manifest'])  # type: ignore
+
+        s3_path = manifest.s3_path
+
+        logger.info(f"s3_path: {s3_path} \n \
+                    token: {token} \n \
+                    execution_id: {execution_id}")
+        processing_status = True
+        try:
+            file_bytes = get_file_bytes_from_s3(s3_path=s3_path)
+
+            start_time = round(time.time() * 1000)
+            response = comprehend.classify_document(
+                Bytes=file_bytes,
+                EndpointArn=comprehend_classifier_arn,
+                DocumentReaderConfig={
+                    'DocumentReadAction': 'TEXTRACT_DETECT_DOCUMENT_TEXT',
+                    'DocumentReadMode': 'FORCE_DOCUMENT_READ_ACTION'
+                }
+            )
+            logger.debug(f"comprehend result: {response}")
+
+            classification_result = "NONE"
+            for c in response['Classes']:
+                if c['Score'] > 0.50:
+                    classification_result = c['Name']
+                    break
+
+            call_duration = round(time.time() * 1000) - start_time
+            logger.info(
+                f"comprehend_sync_generic_call_duration_in_ms: {call_duration}"
+            )
+            try:
+                step_functions_client.send_task_success(
+                    taskToken=token,
+                    output=json.dumps(
+                        {"documentType": classification_result}))
+            except step_functions_client.exceptions.InvalidToken:
+                logger.error(f"InvalidToken for message: {message} ")
+                sqs.delete_message(QueueUrl=sqs_queue_url,
+                                   ReceiptHandle=receipt_handle)
+            except step_functions_client.exceptions.TaskDoesNotExist:
+                logger.error(f"TaskDoesNotExist for message: {message} ")
+                sqs.delete_message(QueueUrl=sqs_queue_url,
+                                   ReceiptHandle=receipt_handle)
+            except step_functions_client.exceptions.TaskTimedOut:
+                logger.error(f"TaskTimedOut for message: {message} ")
+                sqs.delete_message(QueueUrl=sqs_queue_url,
+                                   ReceiptHandle=receipt_handle)
+            except step_functions_client.exceptions.InvalidOutput:
+                # Not sure if to delete here or not, could be a bug in the code that a hot fix could solve,
+                # but don't want to retry infinite, which can cause run-away-cost. For now, delete
+                logger.error(f"InvalidOutput for message: {message} ")
+                sqs.delete_message(QueueUrl=sqs_queue_url,
+                                   ReceiptHandle=receipt_handle)
+
+        except comprehend.exceptions.TooManyRequestsException as e:
+            # try again, will throw Exception for Lambda and not delete from queue
+            logger.error(e, exc_info=True)
+            logger.error(f"TooManyRequestsException for: {s3_path} to Comprehend.")
+            if approx_receive_count < sqs_max_retries:
+                # retry message if less than sqs_max_retries attempts
+                processing_status = False
+            else:
+                send_failure_to_step_function("TooManyRequestsException",
+                                              f"{e}\nafter {sqs_max_retries} Lambda retry attempts",
+                                              token, sqs_queue_url, message, receipt_handle)
+        except comprehend.exceptions.TextSizeLimitExceededException as e:
+            logger.error(e, exc_info=True)
+            send_failure_to_step_function('TextSizeLimitExceededException', str(e),
+                                          token, sqs_queue_url, message, receipt_handle)
+        except comprehend.exceptions.InvalidRequestException as e:
+            logger.error(e, exc_info=True)
+            logger.error(f"InvalidRequestException for: {s3_path} to Comprehend.")
+            send_failure_to_step_function("InvalidRequestException", str(e), token,
+                                          sqs_queue_url, message, receipt_handle)
+        except ClientError as e:
+            logger.error(e, exc_info=True)
+            if e.response['Error']['Code'] == 'ThrottlingException':
+                logger.error(f"ThrottlingException - failed to send: {s3_path} to Comprehend.")
+                if approx_receive_count < sqs_max_retries:
+                    # retry message if less than sqs_max_retries attempts
+                    processing_status = False
+                else:
+                    send_failure_to_step_function("ThrottlingException",
+                                                  f"{e}\nafter {sqs_max_retries} Lambda retry attempts",
+                                                  token, sqs_queue_url, message, receipt_handle)
+        except Exception as e:
+            send_failure_to_step_function(e, 'unhandled', str(e), token, sqs_queue_url, message, receipt_handle)
+
+        if not processing_status:
+            sqs.change_message_visibility(QueueUrl=sqs_queue_url,
+                                          ReceiptHandle=receipt_handle,
+                                          VisibilityTimeout=randint(sqs_min_vis_timeout, sqs_max_vis_timeout))
+            raise Exception()

--- a/lambda/comprehend_sync/env.json
+++ b/lambda/comprehend_sync/env.json
@@ -1,0 +1,6 @@
+{
+    "HelloWorldFunction": {
+        "COMPREHEND_CLASSIFIER_ARN": "arn:aws:comprehend:<REGION>:<ACCOUNT_ID>:document-classifier-endpoint/<CLASSIFIER_NAME>",
+        "SQS_QUEUE_URL": "https://sqs.<REGION>.amazonaws.com/<ACCOUNT_ID>/<SQS_QUEUE_NAME>"
+    }
+}

--- a/lambda/comprehend_sync/events/event.json
+++ b/lambda/comprehend_sync/events/event.json
@@ -1,0 +1,20 @@
+{
+    "Records": [
+        {
+            "messageId": "<MESSAGE_ID>",
+            "receiptHandle": "<RECEIPT_HANDLE>",
+            "body": "{\"Token\": \"<TOKEN>\", \"Payload\": {\"manifest\": {\"s3Path\": \"s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/10.pdf\"}, \"numberOfPages\": 1, \"mime\": \"application/pdf\"}, \"ExecutionId\": \"arn:aws:states:<REGION>:<ACCOUNT_ID>:execution:<STATE_MACHINE_NAME>:<EXECUTION_NAME>\"}",
+            "attributes": {
+                "ApproximateReceiveCount": "2",
+                "SentTimestamp": "<SENT_TIMESTAMP>",
+                "SenderId": "<SENDER_ID>",
+                "ApproximateFirstReceiveTimestamp": "<APPROXIMATE_FIRST_RECEIVE_TIMESTAMP>"
+            },
+            "messageAttributes": {},
+            "md5OfBody": "<MD5_OF_BODY>",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:<REGION>:<ACCOUNT_ID>:<SQS_QUEUE_NAME>",
+            "awsRegion": "<REGION>"
+        }
+    ]
+}

--- a/lambda/comprehend_sync/template.yaml
+++ b/lambda/comprehend_sync/template.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  python3.9
+
+  Sample SAM Template for sam-app
+
+Globals:
+  Function:
+    Timeout: 900
+
+Resources:
+  SyncFunction:
+    Type: AWS::Serverless::Function 
+    Properties:
+      PackageType: Image
+      Environment:
+        Variables:
+          COMPREHEND_CLASSIFIER_ARN: "arn:aws:comprehend:<REGION>:<ACCOUNT_ID>:document-classifier-endpoint/<CLASSIFIER_NAME>"
+          SQS_QUEUE_URL: "https://sqs.<REGION>.amazonaws.com/<ACCOUNT_ID>/<SQS_QUEUE_NAME>"
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: .
+      DockerTag: python3.9-v1
+

--- a/lambda/comprehend_sync/test_sam_local.sh
+++ b/lambda/comprehend_sync/test_sam_local.sh
@@ -1,0 +1,2 @@
+sam build
+sam local invoke -e events/event.json -n env.json

--- a/lambda/config_prefill/env.json
+++ b/lambda/config_prefill/env.json
@@ -1,6 +1,6 @@
 {
     "PutOnSQSFunction": {
-        "CONFIGURATION_TABLE": "DocumentSplitterWorkflow-DocumentSplitterWorkflowConfiguratorTextractConfigurationTableF23A3F4D-18401CI5OCUHI",
+        "CONFIGURATION_TABLE": "<CONFIGURATION_TABLE_NAME>",
         "LOG_LEVEL": "DEBUG"
     }
 }

--- a/lambda/config_prefill/events/simple-event.json
+++ b/lambda/config_prefill/events/simple-event.json
@@ -1,6 +1,6 @@
 {
     "manifest": {
-        "S3Path": "s3://sdx-textract-us-east-1/employeeapp20210510.png"
+        "S3Path": "s3://example-bucket/example-image.png"
     },
     "mime": "image/png",
     "numberOfPages": 1

--- a/lambda/config_prefill/template.yaml
+++ b/lambda/config_prefill/template.yaml
@@ -18,7 +18,7 @@ Resources:
         - x86_64
       Environment:
         Variables:
-          CONFIGURATION_TABLE: DocumentSplitterWorkflow-DocumentSplitterWorkflowConfiguratorTextractConfigurationTableF23A3F4D-18401CI5OCUHI
+          CONFIGURATION_TABLE: "<CONFIGURATION_TABLE_NAME>"
           LOG_LEVEL: DEBUG
     Metadata:
       Dockerfile: Dockerfile

--- a/lambda/configurator/env.json
+++ b/lambda/configurator/env.json
@@ -1,5 +1,5 @@
 {
     "DeciderFunction": {
-        "CONFIGURATION_TABLE": "RM-PaystubW2configuratorTextractConfigurationTableD0BAEF8E-1AG0QF51SQ4GZ"
+        "CONFIGURATION_TABLE": "<CONFIGURATION_TABLE_NAME>"
     }
 }

--- a/lambda/configurator/events/event.json
+++ b/lambda/configurator/events/event.json
@@ -1,19 +1,17 @@
 {
-    "manifest": {
-        "s3Path": "s3://rm-schademcdkidpstackpaystubw2b23e1d7e-pb6eve1ca8yk/uploads/W2_1_reMars.png"
-    },
-    "mime": "image/png",
-    "classification": {
-        "documentType": "AWS_W2"
-    },
-    "numberOfPages": 1,
-    "Random": {
-        "randomNumber": 5
-    },
-    "textract_result": {
-        "TextractOutputJsonPath": "s3://rm-schademcdkidpstackpaystubw2b23e1d7e-pb6eve1ca8yk/textract-output/W2_1_reMars2022-06-21T00:46:07.656503/W2_1_reMars.json"
-    },
-    "txt_output_location": {
-        "TextractOutputCSVPath": "s3://rm-schademcdkidpstackpaystubw2b23e1d7e-pb6eve1ca8yk/txt_output/2022-06-21T00:46:09+00:00/W2_1_reMars.txt"
-    }
+  "manifest": {
+    "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLAODED_FILE_NAME>/<TIMESTAMP>/12.pdf"
+  },
+  "numberOfPages": 1,
+  "mime": "application/pdf",
+  "textract_result": {
+    "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/12<TIMESTAMP>/12.json"
+  },
+  "txt_output_location": {
+    "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/12.txt"
+  },
+  "classification": {
+    "documentType": "property_affidavit",
+    "documentTypeWithPageNum": "property_affidavit_page1"
+  }
 }

--- a/lambda/configurator/template.yaml
+++ b/lambda/configurator/template.yaml
@@ -18,7 +18,7 @@ Resources:
         - x86_64
       Environment:
         Variables:
-            CONFIGURATION_TABLE: "RM-PaystubW2configuratorTextractConfigurationTableD0BAEF8E-1AG0QF51SQ4GZ"
+            CONFIGURATION_TABLE: "<CONFIGURATION_TABLE_NAME>"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .

--- a/lambda/enumerate_pages/events/event.json
+++ b/lambda/enumerate_pages/events/event.json
@@ -1,15 +1,15 @@
 [
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/1.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/1.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/12023-01-10T01:59:03.577187/1.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/1<TIMESTAMP>/1.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:05+00:00/1.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/1.txt"
     },
     "classification": {
       "documentType": "acord125"
@@ -17,15 +17,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/2.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/2.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/22023-01-10T01:59:03.873165/2.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/2<TIMESTAMP>/2.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:05+00:00/2.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/2.txt"
     },
     "classification": {
       "documentType": "acord125"
@@ -33,15 +33,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/3.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/3.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/32023-01-10T01:59:03.267094/3.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/3<TIMESTAMP>/3.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/3.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/3.txt"
     },
     "classification": {
       "documentType": "acord125"
@@ -49,15 +49,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/4.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/4.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/42023-01-10T01:59:04.174936/4.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/4<TIMESTAMP>/4.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:06+00:00/4.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/4.txt"
     },
     "classification": {
       "documentType": "acord125"
@@ -65,15 +65,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/5.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/5.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/52023-01-10T01:59:03.244999/5.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/5<TIMESTAMP>/5.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/5.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/5.txt"
     },
     "classification": {
       "documentType": "acord126"
@@ -81,15 +81,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/6.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/6.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/62023-01-10T01:59:03.203723/6.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/6<TIMESTAMP>/6.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/6.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/6.txt"
     },
     "classification": {
       "documentType": "acord126"
@@ -97,15 +97,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/7.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/7.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/72023-01-10T01:59:03.441274/7.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/7<TIMESTAMP>/7.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/7.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/7.txt"
     },
     "classification": {
       "documentType": "acord126"
@@ -113,15 +113,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/8.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/8.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/82023-01-10T01:59:03.396358/8.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/8<TIMESTAMP>/8.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/8.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/8.txt"
     },
     "classification": {
       "documentType": "acord126"
@@ -129,15 +129,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/9.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/9.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/92023-01-10T01:59:03.209217/9.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/9<TIMESTAMP>/9.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/9.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/9.txt"
     },
     "classification": {
       "documentType": "acord140"
@@ -145,15 +145,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/10.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/10.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/102023-01-10T01:59:03.147332/10.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/10<TIMESTAMP>/10.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/10.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/10.txt"
     },
     "classification": {
       "documentType": "acord140"
@@ -161,15 +161,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/11.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/11.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/112023-01-10T01:59:03.295771/11.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/11<TIMESTAMP>/11.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:04+00:00/11.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/11.txt"
     },
     "classification": {
       "documentType": "acord140"
@@ -177,15 +177,15 @@
   },
   {
     "manifest": {
-      "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/sample-doc/2023-01-10T01:58:57.056701/12.pdf"
+      "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/12.pdf"
     },
     "numberOfPages": 1,
     "mime": "application/pdf",
     "textract_result": {
-      "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-output/122023-01-10T01:59:02.562386/12.json"
+      "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/12<TIMESTAMP>/12.json"
     },
     "txt_output_location": {
-      "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6/textract-text-output/2023-01-10T01:59:03+00:00/12.txt"
+      "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/12.txt"
     },
     "classification": {
       "documentType": "property_affidavit"

--- a/lambda/enumerate_pages/template.yaml
+++ b/lambda/enumerate_pages/template.yaml
@@ -16,7 +16,7 @@ Resources:
       PackageType: Image
       Environment:
         Variables:
-            CONFIGURATION_TABLE: "DocumentSplitterWorkflow-DocumentSplitterWorkflowConfiguratorTextractConfigurationTableF23A3F4D-18401CI5OCUHI"
+            CONFIGURATION_TABLE: "<CONFIGURATION_TABLE_NAME>"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .

--- a/lambda/generatecsv/app/main.py
+++ b/lambda/generatecsv/app/main.py
@@ -89,12 +89,10 @@ def lambda_handler(event, _):
     logger.debug(f"version: {version}")
     logger.debug(json.dumps(event))
     csv_s3_output_prefix = os.environ.get('CSV_S3_OUTPUT_PREFIX')
-    output_type = os.environ.get('OUTPUT_TYPE', 'CSV')
     csv_s3_output_bucket = os.environ.get('CSV_S3_OUTPUT_BUCKET')
 
     logger.info(f"CSV_S3_OUTPUT_PREFIX: {csv_s3_output_prefix} \n\
-        CSV_S3_OUTPUT_BUCKET: {csv_s3_output_bucket} \n\
-            OUTPUT_TYPE: {output_type}")
+        CSV_S3_OUTPUT_BUCKET: {csv_s3_output_bucket}")
     task_token = event['Token']
     try:
         if not csv_s3_output_prefix or not csv_s3_output_bucket:
@@ -119,52 +117,41 @@ def lambda_handler(event, _):
 
         timestamp = datetime.datetime.now().astimezone().replace(
             microsecond=0).isoformat()
-        result_value = ""
-        if output_type == 'CSV':
-            has_signature, block_map, table_blocks = get_signature_table_info(file_json)
-            trp2_doc: t2.TDocument = t2.TDocumentSchema().load(
-                file_json)  # type: ignore
 
-            key_value_list = convert_form_to_list_trp2(trp2_doc=trp2_doc)  # type: ignore
-            table_value_list = get_table_list(block_map, table_blocks)  # type: ignore
-            queries_value_list = convert_queries_to_list_trp2(trp2_doc=trp2_doc)  # type: ignore
-            
-            csv_output = io.StringIO()
-            csv_writer = csv.writer(csv_output,
-                                    delimiter=",",
-                                    quotechar='"',
-                                    quoting=csv.QUOTE_MINIMAL)
-            for page in key_value_list:
-                csv_writer.writerows(
-                    [[timestamp, classification, base_filename, "FORMS"] +
-                     [x[1], x[3]] for x in page]) # only include key name and key value
-            for page in queries_value_list:
-                csv_writer.writerows(
-                    [[timestamp, classification, base_filename, "QUERIES"] +
-                     [x[1], x[3]] for x in page]) # only include alias and query result
-            for page in table_value_list:
-                csv_writer.writerows(
-                    [[timestamp, classification, base_filename, "TABLES"] + x
-                     for x in page])
-            if has_signature:
-                signature_value = "Contains Signature"
-            else:
-                signature_value = "Does NOT Contain Signature"
-            csv_writer.writerow(
-                [timestamp, classification, base_filename,
-                 "SIGNATURES", "HAS_SIGNATURE", signature_value])
-            csv_s3_output_key = f"{csv_s3_output_prefix}/{timestamp}/{base_filename_no_suffix}.csv"
-            result_value = csv_output.getvalue()
-        elif output_type == 'LINES':
-            csv_s3_output_key = f"{csv_s3_output_prefix}/{timestamp}/{base_filename_no_suffix}.txt"
-            trp2_doc: t2.TDocument = t2.TDocumentSchema().load(
-                file_json)  # type: ignore
-            for page in trp2_doc.pages:
-                result_value += t2.TDocument.get_text_for_tblocks(
-                    trp2_doc.lines(page=page))
-            logger.debug(f"got {len(result_value)}")
+        has_signature, block_map, table_blocks = get_signature_table_info(file_json)
+        trp2_doc: t2.TDocument = t2.TDocumentSchema().load(
+            file_json)  # type: ignore
+
+        key_value_list = convert_form_to_list_trp2(trp2_doc=trp2_doc)  # type: ignore
+        table_value_list = get_table_list(block_map, table_blocks)  # type: ignore
+        queries_value_list = convert_queries_to_list_trp2(trp2_doc=trp2_doc)  # type: ignore
+
+        csv_output = io.StringIO()
+        csv_writer = csv.writer(csv_output,
+                                delimiter=",",
+                                quotechar='"',
+                                quoting=csv.QUOTE_MINIMAL)
+        for page in key_value_list:
+            csv_writer.writerows(
+                [[timestamp, classification, base_filename, "FORMS"] +
+                 [x[1], x[3]] for x in page])  # only include key name and key value
+        for page in queries_value_list:
+            csv_writer.writerows(
+                [[timestamp, classification, base_filename, "QUERIES"] +
+                 [x[1], x[3]] for x in page])  # only include alias and query result
+        for page in table_value_list:
+            csv_writer.writerows(
+                [[timestamp, classification, base_filename, "TABLES"] + x
+                 for x in page])
+        if has_signature:
+            signature_value = "Contains Signature"
         else:
-            raise ValueError(f"output_type '${output_type}' not supported: ")
+            signature_value = "Does NOT Contain Signature"
+        csv_writer.writerow(
+            [timestamp, classification, base_filename,
+             "SIGNATURES", "HAS_SIGNATURE", signature_value])
+        csv_s3_output_key = f"{csv_s3_output_prefix}/{timestamp}/{base_filename_no_suffix}.csv"
+        result_value = csv_output.getvalue()
 
         s3_client.put_object(Body=bytes(result_value.encode('UTF-8')),
                              Bucket=csv_s3_output_bucket,

--- a/lambda/generatecsv/env.json
+++ b/lambda/generatecsv/env.json
@@ -1,6 +1,6 @@
 {
     "Function": {
-        "CSV_S3_OUTPUT_BUCKET": "documentsplitterworkflow-textractsimplesyncworkfl-14xa314007k78",
+        "CSV_S3_OUTPUT_BUCKET": "<S3_OUTPUT_BUCKET>",
         "CSV_S3_OUTPUT_PREFIX": "textract-csv-output",
         "LOG_LEVEL": "DEBUG"
     }

--- a/lambda/generatecsv/events/event.json
+++ b/lambda/generatecsv/events/event.json
@@ -1,8 +1,8 @@
 {
-    "Token": "AQCcAAAAKgAAAAMAAAAAAAAAAU/mwnJYbMBEpVNAZofbWH4afmpHpNmKqMfe1ZS70F6HTtniio7DPw2ATBewFfODqjI6CfNmQHR2bdX1oP/YwaG9c2lXdKc8hzngdkRiA+rRj9yT5kjcfpPFUAyS6SPh5OtTqS9+aZkILBsT8i9txn3werLFUDl1mjgHVyDRFPssvWaiJrs4J6m5+ZIJcFtnge2qVdVaODDBm4bHv4vlv18Bv+S9AbDasecmJ82t6LUB+DNVSuZVsa8mZrQuGFzDQBury3tVpD7D/d7wJOI4oKxEC66SVcGWnvhh7BDdYjR2vXwl5VkF3iBQ+pWmISJ5c6IL1wKnY1sh6TsBieAJLFqYblAzu3l9i1aW9ucdYk8PzarvC7S6dUvjd8oE4cc2Z99Xy3VkoabxECyDEVEwrrlSk1st3It3Z3IwId10k2cN0z7qIdH0Rav0qWD7IFlDT2k+Kv4d02W+hrDwbwyj3JC+kBJ7zBjFYHVjvqTsi70TU/aeJTJX3yV4jF4YXMkmox4fKW6eqAcAB+QbWP7leEtJmhg+aVwxdV7tnh6d5W1MstAEMzcDeup/76wqGmuzmlQV5UNz6rEbXq3AXLkQQYVVT+e5TDBWqd+u19gqyy3Ty0rwxCa+WnXKD9ugzj+uYFD5atSfEgXmoCIw9SDu21bvD4rv",
+    "Token": "<TOKEN>",
     "Payload": {
         "manifest": {
-            "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14xa314007k78/textract-output/sample-doc/2023-01-10T18:00:29.174469/12.pdf",
+            "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/12.pdf",
             "queriesConfig": [
                 {
                     "text": "What is your name?",
@@ -33,10 +33,10 @@
         "numberOfPages": 1,
         "mime": "application/pdf",
         "textract_result": {
-            "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14xa314007k78/textract-output/122023-01-10T18:02:23.700962/12.json"
+          "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/12<TIMESTAMP>/12.json"
         },
         "txt_output_location": {
-            "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-14xa314007k78/textract-text-output/2023-01-10T18:00:38+00:00/12.txt"
+          "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/12.txt"
         },
         "classification": {
             "documentType": "property_affidavit",
@@ -44,5 +44,5 @@
         },
         "numberOfQueries": 5
     },
-    "ExecutionId": "arn:aws:states:us-east-1:988522673913:execution:DocumentSplitterWorkflowFF44A6FE-IZaUJrchLY5K:sample-docpdf2023-01-10T1800259998760000"
+    "ExecutionId": "arn:aws:states:<REGION>:<ACCOUNT_ID>:execution:<STATE_MACHINE_NAME>:<EXECUTION_NAME>"
 }

--- a/lambda/generatecsv/template.yaml
+++ b/lambda/generatecsv/template.yaml
@@ -17,7 +17,7 @@ Resources:
       Environment:
         Variables:
           CSV_S3_OUTPUT_PREFIX: textract-csv-output
-          CSV_S3_OUTPUT_BUCKET: documentsplitterworkflow-textractsimplesyncworkfl-14xa314007k78
+          CSV_S3_OUTPUT_BUCKET: "<S3_OUTPUT_BUCKET>"
           LOG_LEVEL: DEBUG
     Metadata:
       Dockerfile: Dockerfile

--- a/lambda/join_csv/events/event.json
+++ b/lambda/join_csv/events/event.json
@@ -1,9 +1,9 @@
 {
   "document_type": "acord140",
   "output_csv_paths": [
-    "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T04:15:40+00:00/9.csv",
-    "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T04:15:54+00:00/10.csv",
-    "s3://documentsplitterworkflow-textractsimplesyncworkfl-14uq5wb21n1hw/textract-csv-output/2023-01-06T04:16:38+00:00/11.csv"
+    "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/9.csv",
+    "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/10.csv",
+    "s3://<S3_OUTPUT_BUCKET>/<S3_CSV_OUTPUT_PREFIX>/<TIMESTAMP>/11.csv"
   ],
   "original_document_pages": "9-11"
 }

--- a/lambda/map_classifications_lambda/env.json
+++ b/lambda/map_classifications_lambda/env.json
@@ -1,6 +1,6 @@
 {
     "StartFunction": {
-        "STATE_MACHINE_ARN": "arn:aws:states:us-east-1:913165245630:stateMachine:IDPWorkflowPython85B937F9-Pnw2MyHSOXR8",
+        "STATE_MACHINE_ARN": "arn:aws:states:<REGION>:<ACCOUNT_ID>:stateMachine:<STATE_MACHINE_NAME>",
         "LOG_LEVEL": "DEBUG"
     }
 }

--- a/lambda/map_classifications_lambda/template.yaml
+++ b/lambda/map_classifications_lambda/template.yaml
@@ -18,7 +18,7 @@ Resources:
         - x86_64
       Environment:
         Variables:
-          STATE_MACHINE_ARN: textract-output
+          STATE_MACHINE_ARN: arn:aws:states:<REGION>:<ACCOUNT_ID>:stateMachine:<STATE_MACHINE_NAME>
           LOG_LEVEL: DEBUG
     Metadata:
       Dockerfile: Dockerfile

--- a/lambda/put_on_sqs/Dockerfile
+++ b/lambda/put_on_sqs/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.9-x86_64
+RUN /var/lang/bin/python -m pip install --upgrade pip
+
+# Copy function code
+COPY app/* ${LAMBDA_TASK_ROOT}/
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "main.lambda_handler" ]

--- a/lambda/put_on_sqs/app/entry.sh
+++ b/lambda/put_on_sqs/app/entry.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+    exec /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric $1
+else
+    exec /usr/local/bin/python -m awslambdaric $1
+fi

--- a/lambda/put_on_sqs/app/main.py
+++ b/lambda/put_on_sqs/app/main.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from random import randint
+
+import boto3
+import json
+
+logger = logging.getLogger(__name__)
+__version__ = "0.0.1"
+sqs_client = boto3.client('sqs')
+
+
+def lambda_handler(event, _):
+    log_level = os.environ.get('LOG_LEVEL', 'INFO')
+    logger.setLevel(log_level)
+    logger.debug(json.dumps(event))
+    logger.debug(f"version: {__version__}")
+    logger.debug(f"boto3 version: {boto3.__version__}")
+
+    sqs_queue_url = os.environ.get('SQS_QUEUE_URL', '')
+    if not sqs_queue_url:
+        raise ValueError(f'no SQS_QUEUE defined: {sqs_queue_url}')
+    sqs_max_delay = int(os.environ.get('SQS_MAX_DELAY', 15))
+
+    response = sqs_client.send_message(QueueUrl=sqs_queue_url,
+                                       MessageBody=json.dumps(event),
+                                       DelaySeconds=randint(1, sqs_max_delay))
+    logger.debug(response)

--- a/lambda/put_on_sqs/env.json
+++ b/lambda/put_on_sqs/env.json
@@ -1,0 +1,6 @@
+{
+    "PutOnSQSFunction": {
+        "SQS_QUEUE_URL": "https://sqs.<REGION>.amazonaws.com/<ACCOUNT_ID>/<SQS_QUEUE_NAME>",
+        "LOG_LEVEL": "DEBUG"
+    }
+}

--- a/lambda/put_on_sqs/events/event.json
+++ b/lambda/put_on_sqs/events/event.json
@@ -1,0 +1,12 @@
+{
+  "Token": "<TOKEN>",
+  "Payload": {
+    "manifest": {
+      "S3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/12.pdf"
+    },
+    "mime": "application/pdf",
+    "classification": null,
+    "numberOfPages": 1
+  },
+  "ExecutionId": "arn:aws:states:<REGION>:<ACCOUNT_ID>:execution:<STATE_MACHINE_NAME>:<EXECUTION_NAME>"
+}

--- a/lambda/put_on_sqs/template.yaml
+++ b/lambda/put_on_sqs/template.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  python3.9
+
+  Sample SAM Template for sam-app
+
+Globals:
+  Function:
+    Timeout: 900
+
+Resources:
+  PutOnSQSFunction:
+    Type: AWS::Serverless::Function 
+    Properties:
+      PackageType: Image
+      Architectures:
+        - x86_64
+      Environment:
+        Variables:
+          SQS_QUEUE_URL: "https://sqs.<REGION>.amazonaws.com/<ACCOUNT_ID>/<SQS_QUEUE_NAME>"
+          LOG_LEVEL: DEBUG
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: .
+      DockerTag: python3.9-v1
+

--- a/lambda/put_on_sqs/test_sam_local.sh
+++ b/lambda/put_on_sqs/test_sam_local.sh
@@ -1,0 +1,2 @@
+sam build
+sam local invoke -e events/event.json -n env.json

--- a/lambda/startstepfunction/env.json
+++ b/lambda/startstepfunction/env.json
@@ -1,6 +1,6 @@
 {
     "StartFunction": {
-        "STATE_MACHINE_ARN": "arn:aws:states:us-east-1:913165245630:stateMachine:IDPWorkflowPython85B937F9-Pnw2MyHSOXR8",
+        "STATE_MACHINE_ARN": "arn:aws:states:<REGION>:<ACCOUNT_ID>:stateMachine:<STATE_MACHINE_NAME>",
         "LOG_LEVEL": "DEBUG"
     }
 }

--- a/lambda/startstepfunction/template.yaml
+++ b/lambda/startstepfunction/template.yaml
@@ -18,7 +18,7 @@ Resources:
         - x86_64
       Environment:
         Variables:
-          STATE_MACHINE_ARN: textract-output
+          STATE_MACHINE_ARN: arn:aws:states:<REGION>:<ACCOUNT_ID>:stateMachine:<STATE_MACHINE_NAME>
           LOG_LEVEL: DEBUG
     Metadata:
       Dockerfile: Dockerfile

--- a/lambda/textract_sync/env.json
+++ b/lambda/textract_sync/env.json
@@ -1,7 +1,7 @@
 {
     "HelloWorldFunction": {
         "S3_OUTPUT_PREFIX": "textract-csv-output",
-        "S3_OUTPUT_BUCKET": "documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6",
-        "SQS_QUEUE_URL": ""
+        "S3_OUTPUT_BUCKET": "<S3_OUTPUT_BUCKET>",
+        "SQS_QUEUE_URL": "<SQS_QUEUE_URL>"
     }
 }

--- a/lambda/textract_sync/events/event.json
+++ b/lambda/textract_sync/events/event.json
@@ -1,5 +1,5 @@
 {
-    "Token": "AQCcAAAAKgAAAAMAAAAAAAAAASb4gIRL7YhBg5sgME/rgcYI/R67z9fXd1wvaA3q1VU+7bFhprANJeK9bRR6xEDHS9GbsUffwMBMcq5tHlCy9mhn0jQWYSKy1+x9EqHoajRBhuP3vNAJUbtb48eIbMS+2SU6Bv42J2s/XvEd+CgrNsDDXm2AcbN1KzWxOn9sl+j65X2Ul8f/hyTYL3frTDeS/vyjGgM/toTxm8UpKpeIGfLRLzPgAXmjXOPLh2kxNJ9YQxmpx8H9CSFNzVwnuwHNiYyGd1kg/Mh/J0C+9HK2L6tNcuTRESwM46MdVSubVVZjmw0bm361j4d4pGvmFU+dwpmGNbkWWdlOCo/q1iBOPTUJU9FQk41HwX/Ox/i8WO0JanAAZkFNRjIHVawD74EdmT5WdVbqNbM4ETxlB0BcxP2VYAnsPxMNxyEMfv5mzwhhtm8+TWE/k2k+gTdzxNOAaJ6/71oyj/BgidtPVlhEN9dEF5eYBFgDqrR5IPpsUv76TmuU4slg/hYgPWxuBDAwNh1GLp8X88MQn3psW5LxUxRp88IVPlvn8g8hETVjetvQsVHrFjysSggM1gBoL34I1ce88JOsWgG2WgFJ0iD3UOjX64XbbeNlbJ1ztdEl7ptuT9VXKRoh+s56evHtLmw/MPgzPXpRsRkewz1e4Hsef25HJnIO",
+    "Token": "<TOKEN>",
     "Payload": {
         "manifest": {
             "queriesConfig": [
@@ -96,7 +96,7 @@
                     "alias": "ACORD_140_PAGE1_REMARKS"
                 }
             ],
-            "s3Path": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1392pqv2djdit/textract-output/sample-doc/2023-01-10T02:39:51.872446/9.pdf",
+            "s3Path": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/<UPLOADED_FILE_NAME>/<TIMESTAMP>/9.pdf",
             "textractFeatures": [
                 "FORMS",
                 "TABLES",
@@ -106,10 +106,10 @@
         "numberOfPages": 1,
         "mime": "application/pdf",
         "textract_result": {
-            "TextractOutputJsonPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1392pqv2djdit/textract-output/92023-01-10T02:39:59.353908/9.json"
+            "TextractOutputJsonPath": "s3://<S3_OUTPUT_BUCKET>/<S3_OUTPUT_PREFIX>/9<TIMESTAMP>/9.json"
         },
         "txt_output_location": {
-            "TextractOutputCSVPath": "s3://documentsplitterworkflow-textractsimplesyncworkfl-1392pqv2djdit/textract-text-output/2023-01-10T02:40:01+00:00/9.txt"
+            "TextractOutputCSVPath": "s3://<S3_OUTPUT_BUCKET>/<S3_TXT_OUTPUT_PREFIX>/<TIMESTAMP>/9.txt"
         },
         "classification": {
             "documentType": "acord140",
@@ -117,5 +117,5 @@
         },
         "numberOfQueries": 23
     },
-    "ExecutionId": "arn:aws:states:us-east-1:988522673913:execution:DocumentSplitterWorkflowFF44A6FE-odd07KfLrIID:sample-docpdf2023-01-10T023946779984"
+    "ExecutionId": "arn:aws:states:<REGION>:<ACCOUNT_ID>:execution:<STATE_MACHINE_NAME>:<EXECUTION_NAME>"
 }

--- a/lambda/textract_sync/template.yaml
+++ b/lambda/textract_sync/template.yaml
@@ -17,8 +17,8 @@ Resources:
       Environment:
         Variables:
           S3_OUTPUT_PREFIX: textract-csv-output
-          S3_OUTPUT_BUCKET: documentsplitterworkflow-textractsimplesyncworkfl-1oy8gsfyhnhz6
-          SQS_QUEUE_URL: SchademCdkStackPaystubStack-textractsynctaskSyncRequestsBC26E72B-kID9dZUtmCZM
+          S3_OUTPUT_BUCKET: "<S3_OUTPUT_BUCKET>"
+          SQS_QUEUE_URL: "<SQS_QUEUE_URL>"
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: .


### PR DESCRIPTION
*Issue #, if available:*
N/A


*Description of changes:*

1. **Comprehend one-step classification:**
    - Leverages the Comprehend ClassifyDocument API [Bytes](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Bytes) and [DocumentReaderConfig](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-DocumentReaderConfig) parameters, which allow one-step classification on PDFs, images, text files, and Word documents. This bypasses the three-step method of calling the Textract DetectDocumentText API, parsing the JSON response to generate text, and inputting that text into the ClassifyDocument API via the Text argument.
    - Replaces TextractSyncOCR, GenerateText, and ComprehendGenericSyncSfn Tasks with a new Classification Task. It invokes the PutOnSQS Lambda, which sends messages to the ComprehendRequests SQS Queue to trigger the ComprehendSyncCall Lambda. The file bytes that are inputted into the Comprehend ClassifyDocument API are from the one-page PDF or image outputted by the Document Splitter Task.
    - Based on the comprehend_sync and put_on_sqs Lambdas from https://github.com/aws-samples/amazon-textract-idp-cdk-constructs/tree/main/lambda. Includes Lambda environment variables to stagger request times and to set a maximum number of retry attempts if ClassifyDocument API requests are throttled.
    - Modifies generatecsv Lambda, as the only output type is now CSV (does not use LINES).


2. **Anonymize ARNs, S3 URIs, and resource names:**
    - Ex. use placeholders for S3 bucket names and AWS Account IDs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
